### PR TITLE
[WIP] Win32/Visual C++(Visual Studio) 계열에서의 추가적인 지원

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -112,3 +112,4 @@ fabric.properties
 
 # Android studio 3.1+ serialized cache file
 .idea/caches/build_file_checksums.ser
+.vs

--- a/azalea/CMakeLists.txt
+++ b/azalea/CMakeLists.txt
@@ -67,5 +67,12 @@ add_dependencies(azalea resource)
 # Use the Widgets module from Qt 5.
 target_link_libraries(azalea Qt5::Widgets Qt5::Network Qt5::Quick Qt5::QuickWidgets Qt5::WebSockets)
 
+if (WIN32)
+    execute_process(
+        COMMAND "${Qt5_DIR}/../../../bin/windeployqt.exe" "${CMAKE_CURRENT_BINARY_DIR}/azalea.exe"
+        ENCODING UTF8
+    )
+endif (WIN32)
+
 # Install the executable
 install(TARGETS azalea DESTINATION bin)

--- a/azalea/CMakeLists.txt
+++ b/azalea/CMakeLists.txt
@@ -68,9 +68,8 @@ add_dependencies(azalea resource)
 target_link_libraries(azalea Qt5::Widgets Qt5::Network Qt5::Quick Qt5::QuickWidgets Qt5::WebSockets)
 
 if (WIN32)
-    execute_process(
-        COMMAND "${Qt5_DIR}/../../../bin/windeployqt.exe" "${CMAKE_CURRENT_BINARY_DIR}/azalea.exe"
-        ENCODING UTF8
+	ADD_CUSTOM_COMMAND(TARGET azalea POST_BUILD
+        COMMAND "${Qt5_DIR}/../../../bin/windeployqt.exe" "${CMAKE_CURRENT_BINARY_DIR}/azalea.exe" "--qmldir" "${CMAKE_CURRENT_SOURCE_DIR}/ui" "--no-virtualkeyboard" "--no-translations"
     )
 endif (WIN32)
 

--- a/azalea/CMakeLists.txt
+++ b/azalea/CMakeLists.txt
@@ -68,6 +68,10 @@ add_dependencies(azalea resource)
 target_link_libraries(azalea Qt5::Widgets Qt5::Network Qt5::Quick Qt5::QuickWidgets Qt5::WebSockets)
 
 if (WIN32)
+    if (CMAKE_BUILD_TYPE STREQUAL "Release") 
+        SET_PROPERTY(TARGET azalea PROPERTY WIN32_EXECUTABLE true)
+    endif ()
+
 	ADD_CUSTOM_COMMAND(TARGET azalea POST_BUILD
         COMMAND "${Qt5_DIR}/../../../bin/windeployqt.exe" "${CMAKE_CURRENT_BINARY_DIR}/azalea.exe" "--qmldir" "${CMAKE_CURRENT_SOURCE_DIR}/ui" "--no-virtualkeyboard" "--no-translations"
     )


### PR DESCRIPTION
## 변경 사항
- Visual C++를 통해 Win32용으로 빌드가 끝나면, 의존하는 Qt 라이브러리 등을 자동으로 복사하는 작업을 해 줍니다.
- Release variant로 빌드하면 (`-DCMAKE_BUILD_TYPE=Release`) 콘솔 창이 같이 뜨지 않게 됩니다.

## 수정 필요한 사항
- OpenSSL의 `libssl-VERSION.dll` `libcrypto-VERSION.dll`은 여전히 수동으로 복사해줘야 동작합니다. 
- `install` target을 make 할 경우, 실행파일만 복사될 것입니다. 
- 싱글톤 finalizer에서 컴파일 에러가 납니다. 이유는 모르곘지만 고쳐야 할 것 같습니다.

## 확인된 문제
- 이 레포지토리를 Visual Studio에서 CMake 프로젝트로써 열면 정상적인 코드 수정은 가능하나, 빌드 시 `lupdate.exe`와 관련된 오류가 발생합니다
    - 이 문제는 타겟을 Azalea.exe로만 제한해 clean 후 빌드함으로써 우회할 수 있습니다.

- 빌드는 `cmake -G"NMake makefile"` 등을 통해 커맨드라인으로 빌드하는게 나을 수도 있습니다. 